### PR TITLE
Configure GitHub Pages for Vite build output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - run: touch build/.nojekyll
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build


### PR DESCRIPTION
## Summary
- ensure GitHub Pages serves the Vite `build` output
- touch `.nojekyll` after build so Jekyll is skipped

## Testing
- `npm run build`
- `rg "style\.scss" build`


------
https://chatgpt.com/codex/tasks/task_e_68c16b00823083229abf69187222f30c