### PR TITLE
Adjust hero oval overlap styles

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,0 +1,29 @@
+.hero-section__ovals {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero-oval-wrapper {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-oval-wrapper:not(:first-child) {
+  margin-left: -2.5rem;
+}
+
+.hero-oval-wrapper:nth-child(2) {
+  transform: translateX(-0.75rem);
+  z-index: 5;
+}
+
+.hero-oval-wrapper:nth-child(3) {
+  transform: translateX(-1.5rem);
+  z-index: 4;
+}
+
+.hero-oval--logo {
+  position: relative;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
- switch the hero oval container to a flex layout with negative spacing so the wrappers touch
- offset the second and third oval wrappers and layer the logo oval with a higher z-index

## Testing
- npm run build *(fails: missing asset src/assets/0f6babe4268406b7ddf855a6d902d52cadf0cd93.png)*

------
https://chatgpt.com/codex/tasks/task_e_68c874d513e08322a9bd50c87d5bd734