### PR TITLE
Add hero oval text path overlays

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -19,6 +19,7 @@
 .hero-oval-wrapper {
   display: flex;
   justify-content: center;
+  position: relative;
 }
 
 .hero-oval {
@@ -68,6 +69,40 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
+}
+
+.hero-oval__text-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.hero-oval__text-svg {
+  width: 108%;
+  height: 108%;
+  overflow: visible;
+}
+
+.hero-oval__text-ellipse {
+  fill: none;
+  stroke: transparent;
+}
+
+.hero-oval__text {
+  font-family: 'MenorahGrotesk', sans-serif;
+  font-size: clamp(0.65rem, 1.1vw, 0.95rem);
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  fill: #f8f6f3;
+}
+
+.hero-oval__text-path {
+  text-decoration: none;
 }
 
 .hero-oval__gradient--video {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -23,6 +23,35 @@ const heroVideo = heroVideos.find((video) => video.toLowerCase().endsWith('.mp4'
 
 const heroOvalBaseClass = 'hero-oval';
 
+const heroOvalCaptions = {
+  video: 'The Spiritual Events',
+  logo: 'Co-living, Co-working, Co-serving',
+  photos: 'OmHome Participants'
+} as const;
+
+const renderOvalTextLayer = (idSuffix: string, text: string) => (
+  <div className="hero-oval__text-layer" aria-hidden="true">
+    <svg className="hero-oval__text-svg" viewBox="0 0 360 480" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <path
+          id={`hero-oval-text-path-${idSuffix}`}
+          d="M 180 20 a 160 220 0 1 1 0 440 a 160 220 0 1 1 0 -440"
+        />
+      </defs>
+      <ellipse className="hero-oval__text-ellipse" cx="180" cy="240" rx="160" ry="220" />
+      <text className="hero-oval__text" textAnchor="middle" dominantBaseline="middle">
+        <textPath
+          xlinkHref={`#hero-oval-text-path-${idSuffix}`}
+          startOffset="50%"
+          className="hero-oval__text-path"
+        >
+          {text}
+        </textPath>
+      </text>
+    </svg>
+  </div>
+);
+
 export function HeroSection() {
   const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
 
@@ -83,9 +112,13 @@ export function HeroSection() {
           transition={{ duration: 0.8 }}
           className="hero-section__ovals"
         >
-          <div className="hero-oval-wrapper">{renderVideoOval(false)}</div>
+          <div className="hero-oval-wrapper">
+            {renderOvalTextLayer('video', heroOvalCaptions.video)}
+            {renderVideoOval(false)}
+          </div>
 
           <div className="hero-oval-wrapper">
+            {renderOvalTextLayer('logo', heroOvalCaptions.logo)}
             <div className={`${heroOvalBaseClass} hero-oval--logo`}>
               <div className="hero-oval__gradient hero-oval__gradient--logo" />
               <img
@@ -97,6 +130,7 @@ export function HeroSection() {
           </div>
 
           <div className="hero-oval-wrapper">
+            {renderOvalTextLayer('photos', heroOvalCaptions.photos)}
             <div className={`${heroOvalBaseClass} hero-oval--photos`}>
               {heroPhotos.length ? (
                 heroPhotos.map((photo, index) => (
@@ -123,7 +157,10 @@ export function HeroSection() {
           transition={{ duration: 0.8, delay: 0.2 }}
           className="hero-section__mobile-oval"
         >
-          <div>{renderVideoOval(true)}</div>
+          <div className="hero-oval-wrapper">
+            {renderOvalTextLayer('video-mobile', heroOvalCaptions.video)}
+            {renderVideoOval(true)}
+          </div>
         </motion.div>
 
         <motion.div


### PR DESCRIPTION
## Summary
- add inline SVG text layers with curved captions for each hero oval
- reuse captions for desktop and mobile layouts while keeping the video/logo/photo ovals intact
- style the absolute text overlay to align the SVG ellipse and typography with the oval perimeter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9164b5cd083228d45e02a832c35a4