### PR TITLE
Add consistent tint to hero media assets

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -54,6 +54,11 @@
   object-fit: cover;
 }
 
+.hero-oval__media--tint {
+  filter: sepia(0.3) hue-rotate(-15deg) saturate(1.2);
+  transition: filter 0.4s ease;
+}
+
 .hero-oval__placeholder {
   display: flex;
   align-items: center;
@@ -71,7 +76,12 @@
 }
 
 .hero-oval__gradient--video {
-  background: linear-gradient(115deg, rgba(246, 197, 106, 0.35), transparent 55%, rgba(115, 114, 155, 0.25));
+  background: linear-gradient(
+    120deg,
+    rgba(134, 175, 141, 0.32),
+    transparent 55%,
+    rgba(115, 114, 155, 0.22)
+  );
 }
 
 .hero-oval__gradient--logo {
@@ -79,7 +89,12 @@
 }
 
 .hero-oval__gradient--photos {
-  background: linear-gradient(130deg, rgba(0, 0, 0, 0.25), transparent 55%, rgba(115, 114, 155, 0.2));
+  background: linear-gradient(
+    135deg,
+    rgba(30, 55, 47, 0.35),
+    transparent 50%,
+    rgba(134, 175, 141, 0.24)
+  );
 }
 
 .hero-oval__logo-overlay {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -56,7 +56,7 @@ export function HeroSection() {
           muted
           loop
           playsInline
-          className="hero-oval__media"
+          className="hero-oval__media hero-oval__media--tint"
         />
       ) : (
         <div className="hero-oval__placeholder">
@@ -104,7 +104,7 @@ export function HeroSection() {
                     key={photo}
                     src={photo}
                     alt="Участники OmHome"
-                    className={`hero-oval__photo ${index === currentPhotoIndex ? 'is-active' : ''}`}
+                    className={`hero-oval__photo hero-oval__media--tint ${index === currentPhotoIndex ? 'is-active' : ''}`}
                   />
                 ))
               ) : (


### PR DESCRIPTION
## Summary
- add a reusable tint utility for hero media to warm footage and photography
- apply the tint class to the hero video and rotating photo elements for consistent coloration
- adjust hero gradients to complement the new color treatment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c91a2e7fd08322a6de4e1f510b9d12