### PR TITLE
Restore visible hero ovals with overlap

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -24,7 +24,7 @@
 .hero-oval {
   position: relative;
   width: 100%;
-  max-width: 360px;
+  max-width: 612px;
   aspect-ratio: 3 / 4;
   overflow: hidden;
   border-radius: 9999px;
@@ -109,7 +109,7 @@
 }
 
 .hero-section__mobile-oval .hero-oval {
-  max-width: 320px;
+  max-width: 544px;
 }
 
 .hero-section__cta {
@@ -144,12 +144,12 @@
   }
 
   .hero-oval-wrapper {
-    flex: 0 0 clamp(220px, 26vw, 360px);
-    width: clamp(220px, 26vw, 360px);
+    flex: 0 0 clamp(374px, 44vw, 612px);
+    width: clamp(374px, 44vw, 612px);
   }
 
   .hero-oval-wrapper:not(:first-child) {
-    margin-left: -3.5rem;
+    margin-left: -11.5rem;
   }
 
   .hero-oval-wrapper:nth-child(1) {
@@ -171,11 +171,11 @@
   }
 
   .hero-oval-wrapper {
-    flex: 0 0 clamp(240px, 24vw, 360px);
-    width: clamp(240px, 24vw, 360px);
+    flex: 0 0 clamp(408px, 41vw, 612px);
+    width: clamp(408px, 41vw, 612px);
   }
 
   .hero-oval-wrapper:not(:first-child) {
-    margin-left: -5rem;
+    margin-left: -10.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- set explicit flex-basis widths on desktop hero oval wrappers so the blocks remain visible
- keep the negative margins for overlap while adjusting widths responsively for large screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9243dbf44832281f371ad2c161820