### PR TITLE
Add backgrounds for hero ovals

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -39,6 +39,10 @@
   align-items: center;
   justify-content: center;
   background-color: #1b3a2c;
+  background-image: url('../assets/oval.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .hero-oval__media,
@@ -52,6 +56,7 @@
 
 .hero-oval__media {
   object-fit: cover;
+  z-index: 1;
 }
 
 .hero-oval__placeholder {
@@ -62,12 +67,33 @@
   font-size: 1rem;
   background-color: rgba(115, 114, 155, 0.12);
   color: #73729b;
+  z-index: 2;
+}
+
+.hero-oval__placeholder--image {
+  background-color: transparent;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  color: #ffffff;
+}
+
+.hero-oval__placeholder-message {
+  position: relative;
+  z-index: 1;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background-color: rgba(27, 58, 44, 0.75);
+  backdrop-filter: blur(2px);
+  color: #ffffff;
+  text-align: center;
 }
 
 .hero-oval__gradient {
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 3;
 }
 
 .hero-oval__gradient--video {
@@ -90,12 +116,14 @@
   max-width: 260px;
   pointer-events: none;
   filter: drop-shadow(0 12px 30px rgba(0, 0, 0, 0.35));
+  z-index: 4;
 }
 
 .hero-oval__photo {
   object-fit: cover;
   opacity: 0;
   transition: opacity 2s ease-in-out;
+  z-index: 1;
 }
 
 .hero-oval__photo.is-active {

--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -119,6 +119,11 @@
   z-index: 4;
 }
 
+.hero-oval__logo-overlay--large {
+  width: 140%;
+  max-width: 520px;
+}
+
 .hero-oval__photo {
   object-fit: cover;
   opacity: 0;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'motion/react';
 import logoSvg from '../assets/Logo.svg?url';
+import videoPlaceholderImage from '../assets/hero_photo/2_4.jpeg?url';
 import './HeroSection.css';
 
 const heroPhotos = (Object.values(
@@ -25,6 +26,15 @@ const heroOvalBaseClass = 'hero-oval';
 
 export function HeroSection() {
   const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
+  const [isVideoLoaded, setIsVideoLoaded] = useState(false);
+
+  const handleVideoLoaded = () => {
+    setIsVideoLoaded(true);
+  };
+
+  const handleVideoLoadStart = () => {
+    setIsVideoLoaded(false);
+  };
 
   useEffect(() => {
     if (heroPhotos.length <= 1) {
@@ -48,6 +58,16 @@ export function HeroSection() {
 
   const renderVideoOval = (withLogoOverlay = false) => (
     <div className={`${heroOvalBaseClass} hero-oval--video`}>
+      {(!isVideoLoaded || !heroVideo) ? (
+        <div
+          className="hero-oval__placeholder hero-oval__placeholder--image"
+          style={{ backgroundImage: `url(${videoPlaceholderImage})` }}
+        >
+          {!heroVideo ? (
+            <span className="hero-oval__placeholder-message">Видео скоро будет</span>
+          ) : null}
+        </div>
+      ) : null}
       {heroVideo ? (
         <video
           key={heroVideo}
@@ -57,12 +77,11 @@ export function HeroSection() {
           loop
           playsInline
           className="hero-oval__media"
+          onCanPlay={handleVideoLoaded}
+          onLoadedData={handleVideoLoaded}
+          onLoadStart={handleVideoLoadStart}
         />
-      ) : (
-        <div className="hero-oval__placeholder">
-          Видео скоро будет
-        </div>
-      )}
+      ) : null}
       <div className="hero-oval__gradient hero-oval__gradient--video" />
       {withLogoOverlay ? (
         <img

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -110,7 +110,7 @@ export function HeroSection() {
               <img
                 src={logoSvg}
                 alt="Логотип OmHome"
-                className="hero-oval__logo-overlay"
+                className="hero-oval__logo-overlay hero-oval__logo-overlay--large"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- set the central hero oval to use the oval.jpg artwork as its background
- display the 2_4.jpeg hero image while the hero video loads and reuse it as the no-video fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92e127f4c8322b0d7a4b604ae461d