### PR TITLE
Refine hero ovals backgrounds and mobile carousel

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -39,6 +39,10 @@
   align-items: center;
   justify-content: center;
   background-color: #1b3a2c;
+  background-image: url('../assets/oval.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .hero-oval__media,
@@ -52,6 +56,7 @@
 
 .hero-oval__media {
   object-fit: cover;
+  z-index: 1;
 }
 
 .hero-oval__placeholder {
@@ -62,12 +67,33 @@
   font-size: 1rem;
   background-color: rgba(115, 114, 155, 0.12);
   color: #73729b;
+  z-index: 2;
+}
+
+.hero-oval__placeholder--image {
+  background-color: transparent;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  color: #ffffff;
+}
+
+.hero-oval__placeholder-message {
+  position: relative;
+  z-index: 1;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background-color: rgba(27, 58, 44, 0.75);
+  backdrop-filter: blur(2px);
+  color: #ffffff;
+  text-align: center;
 }
 
 .hero-oval__gradient {
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 3;
 }
 
 .hero-oval__gradient--video {
@@ -90,25 +116,52 @@
   max-width: 260px;
   pointer-events: none;
   filter: drop-shadow(0 12px 30px rgba(0, 0, 0, 0.35));
+  z-index: 4;
+}
+
+.hero-oval__logo-overlay--large {
+  width: 112%;
+  max-width: 416px;
 }
 
 .hero-oval__photo {
   object-fit: cover;
   opacity: 0;
   transition: opacity 2s ease-in-out;
+  z-index: 1;
 }
 
 .hero-oval__photo.is-active {
   opacity: 1;
 }
 
-.hero-section__mobile-oval {
+.hero-section__mobile-slider {
   display: flex;
-  justify-content: center;
+  overflow-x: auto;
+  gap: 1.5rem;
+  scroll-snap-type: x mandatory;
+  scroll-padding: 1rem;
   margin-top: 2.5rem;
+  padding-bottom: 0.5rem;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
-.hero-section__mobile-oval .hero-oval {
+.hero-section__mobile-slider::-webkit-scrollbar {
+  display: none;
+}
+
+.hero-section__mobile-slide {
+  flex: 0 0 100%;
+  scroll-snap-align: center;
+  display: flex;
+  justify-content: center;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.hero-section__mobile-slide .hero-oval {
   max-width: 544px;
 }
 
@@ -135,7 +188,7 @@
     gap: 0;
   }
 
-  .hero-section__mobile-oval {
+  .hero-section__mobile-slider {
     display: none;
   }
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'motion/react';
 import logoSvg from '../assets/Logo.svg?url';
+import videoPlaceholderImage from '../assets/hero_photo/2_4.jpeg?url';
 import './HeroSection.css';
 
 const heroPhotos = (Object.values(
@@ -25,6 +26,15 @@ const heroOvalBaseClass = 'hero-oval';
 
 export function HeroSection() {
   const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
+  const [isVideoLoaded, setIsVideoLoaded] = useState(false);
+
+  const handleVideoLoaded = () => {
+    setIsVideoLoaded(true);
+  };
+
+  const handleVideoLoadStart = () => {
+    setIsVideoLoaded(false);
+  };
 
   useEffect(() => {
     if (heroPhotos.length <= 1) {
@@ -48,6 +58,16 @@ export function HeroSection() {
 
   const renderVideoOval = (withLogoOverlay = false) => (
     <div className={`${heroOvalBaseClass} hero-oval--video`}>
+      {(!isVideoLoaded || !heroVideo) ? (
+        <div
+          className="hero-oval__placeholder hero-oval__placeholder--image"
+          style={{ backgroundImage: `url(${videoPlaceholderImage})` }}
+        >
+          {!heroVideo ? (
+            <span className="hero-oval__placeholder-message">Видео скоро будет</span>
+          ) : null}
+        </div>
+      ) : null}
       {heroVideo ? (
         <video
           key={heroVideo}
@@ -57,12 +77,11 @@ export function HeroSection() {
           loop
           playsInline
           className="hero-oval__media"
+          onCanPlay={handleVideoLoaded}
+          onLoadedData={handleVideoLoaded}
+          onLoadStart={handleVideoLoadStart}
         />
-      ) : (
-        <div className="hero-oval__placeholder">
-          Видео скоро будет
-        </div>
-      )}
+      ) : null}
       <div className="hero-oval__gradient hero-oval__gradient--video" />
       {withLogoOverlay ? (
         <img
@@ -71,6 +90,37 @@ export function HeroSection() {
           className="hero-oval__logo-overlay"
         />
       ) : null}
+    </div>
+  );
+
+  const renderLogoOval = () => (
+    <div className={`${heroOvalBaseClass} hero-oval--logo`}>
+      <div className="hero-oval__gradient hero-oval__gradient--logo" />
+      <img
+        src={logoSvg}
+        alt="Логотип OmHome"
+        className="hero-oval__logo-overlay hero-oval__logo-overlay--large"
+      />
+    </div>
+  );
+
+  const renderPhotosOval = () => (
+    <div className={`${heroOvalBaseClass} hero-oval--photos`}>
+      {heroPhotos.length ? (
+        heroPhotos.map((photo, index) => (
+          <img
+            key={photo}
+            src={photo}
+            alt="Участники OmHome"
+            className={`hero-oval__photo ${index === currentPhotoIndex ? 'is-active' : ''}`}
+          />
+        ))
+      ) : (
+        <div className="hero-oval__placeholder">
+          Фото скоро будут
+        </div>
+      )}
+      <div className="hero-oval__gradient hero-oval__gradient--photos" />
     </div>
   );
 
@@ -85,45 +135,20 @@ export function HeroSection() {
         >
           <div className="hero-oval-wrapper">{renderVideoOval(false)}</div>
 
-          <div className="hero-oval-wrapper">
-            <div className={`${heroOvalBaseClass} hero-oval--logo`}>
-              <div className="hero-oval__gradient hero-oval__gradient--logo" />
-              <img
-                src={logoSvg}
-                alt="Логотип OmHome"
-                className="hero-oval__logo-overlay"
-              />
-            </div>
-          </div>
+          <div className="hero-oval-wrapper">{renderLogoOval()}</div>
 
-          <div className="hero-oval-wrapper">
-            <div className={`${heroOvalBaseClass} hero-oval--photos`}>
-              {heroPhotos.length ? (
-                heroPhotos.map((photo, index) => (
-                  <img
-                    key={photo}
-                    src={photo}
-                    alt="Участники OmHome"
-                    className={`hero-oval__photo ${index === currentPhotoIndex ? 'is-active' : ''}`}
-                  />
-                ))
-              ) : (
-                <div className="hero-oval__placeholder">
-                  Фото скоро будут
-                </div>
-              )}
-              <div className="hero-oval__gradient hero-oval__gradient--photos" />
-            </div>
-          </div>
+          <div className="hero-oval-wrapper">{renderPhotosOval()}</div>
         </motion.div>
 
         <motion.div
           initial={{ opacity: 0, y: 40 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.2 }}
-          className="hero-section__mobile-oval"
+          className="hero-section__mobile-slider"
         >
-          <div>{renderVideoOval(true)}</div>
+          <div className="hero-section__mobile-slide">{renderLogoOval()}</div>
+          <div className="hero-section__mobile-slide">{renderPhotosOval()}</div>
+          <div className="hero-section__mobile-slide">{renderVideoOval(false)}</div>
         </motion.div>
 
         <motion.div


### PR DESCRIPTION
## Summary
- set the central hero oval to use the oval.jpg artwork as its background
- display the 2_4.jpeg hero image while the hero video loads and reuse it as the no-video fallback
- enlarge the OmHome logo inside the central hero oval while dialing the size back about 20% for better balance
- add a mobile swipeable carousel that lets users move from the logo oval to the photos and then the video

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92e127f4c8322b0d7a4b604ae461d