### PR TITLE
Use cover image as hero video placeholder

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { motion } from 'motion/react';
 import logoSvg from '../assets/Logo.svg?url';
-import videoPlaceholderImage from '../assets/hero_photo/2_4.jpeg?url';
+import videoPlaceholderImage from '../assets/cover.png?url';
 import './HeroSection.css';
 
 const heroPhotos = (Object.values(


### PR DESCRIPTION
## Summary
- update the hero video placeholder to reuse the shared cover image

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c99fd185ec8322bd2010294b4679c7