### PR TITLE
Speed up hero photo rotation

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -45,7 +45,7 @@ export function HeroSection() {
 
     const interval = window.setInterval(() => {
       setCurrentPhotoIndex((prev) => (prev + 1) % heroPhotos.length);
-    }, 6000);
+    }, 3000);
 
     return () => window.clearInterval(interval);
   }, []);


### PR DESCRIPTION
## Summary
- reduce the hero photo rotation interval so each image shows for three seconds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ab83aac08322b69cd00aa20ff5f1