### PR TITLE
Fix runtime useRef reference errors

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const translations = {
@@ -57,7 +57,7 @@ const translations = {
 } as const;
 
 export function AboutSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.3 });
   const { language } = useLanguage();
   const { title, sections, stats } = translations[language];

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const translations = {
@@ -19,7 +19,7 @@ const translations = {
 } as const;
 
 export function AuthoritySection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const { title, description, leaders } = translations[language];

--- a/src/components/Code-component-8-14.tsx
+++ b/src/components/Code-component-8-14.tsx
@@ -1,10 +1,10 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { Quote } from 'lucide-react';
 
 export function QuoteSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.3 });
 
   return (

--- a/src/components/ContactsSection.tsx
+++ b/src/components/ContactsSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { MessageCircle, Phone, Instagram, MapPin, ExternalLink } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 
@@ -58,7 +58,7 @@ const translations = {
 } as const;
 
 export function ContactsSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const { title, contacts, description } = translations[language];

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
+import * as React from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 
@@ -121,9 +120,9 @@ const translations = {
 } as const;
 
 export function FAQSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [openIndex, setOpenIndex] = React.useState<number | null>(null);
   const { language } = useLanguage();
   const { title, subtitle, faqData } = translations[language];
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import * as React from 'react';
 import { motion } from 'motion/react';
 import logoSvg from '../assets/Logo.svg?url';
 import videoPlaceholderImage from '../assets/cover.png?url';
@@ -54,11 +54,11 @@ const HAVE_CURRENT_DATA =
     : 2;
 
 export function HeroSection() {
-  const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
-  const [isVideoReady, setIsVideoReady] = useState(false);
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const sliderRef = useRef<HTMLDivElement>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const [currentPhotoIndex, setCurrentPhotoIndex] = React.useState(0);
+  const [isVideoReady, setIsVideoReady] = React.useState(false);
+  const [currentSlide, setCurrentSlide] = React.useState(0);
+  const sliderRef = React.useRef<HTMLDivElement>(null);
+  const videoRef = React.useRef<HTMLVideoElement>(null);
   const { language } = useLanguage();
   const t = translations[language];
 
@@ -94,7 +94,7 @@ export function HeroSection() {
     setIsVideoReady(false);
   };
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (heroPhotos.length <= 1) {
       return;
     }

--- a/src/components/JoinSection.tsx
+++ b/src/components/JoinSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { Sparkles, Coffee, Heart, HandHeart, Music, MessageCircle, Package, Leaf } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 import imgRectangle33 from 'figma:asset/7079ed6ac33259adcd696c14440f8602d1e716fc.png';
@@ -96,7 +96,7 @@ const translations = {
 } as const;
 
 export function JoinSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const { principlesTitle, principlesLink, joinTitle, heroText, participationTitle, cta, principles, participationOptions } =

--- a/src/components/MissionSection.tsx
+++ b/src/components/MissionSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import imgRectangle16 from 'figma:asset/e5af353556f0ccc88d364bf9e9de41dab821cb94.png';
 import imgRectangle17 from 'figma:asset/08a25526285379767f1b263f0136d84372b8d790.png';
@@ -27,7 +27,7 @@ const translations = {
 } as const;
 
 export function MissionSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const { title, missionTitle, missionDescription, atmosphereTitle, atmosphereDescription } = translations[language];

--- a/src/components/ProgramsSection.tsx
+++ b/src/components/ProgramsSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const eventImagesGlob = import.meta.glob('../assets/events/*.{jpg,jpeg,png}', {
@@ -61,7 +61,7 @@ const translations = {
 } as const;
 
 export function ProgramsSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const {

--- a/src/components/QuoteSection.tsx
+++ b/src/components/QuoteSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { Quote } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 
@@ -16,7 +16,7 @@ const translations = {
 } as const;
 
 export function QuoteSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.3 });
   const { language } = useLanguage();
   const { quote } = translations[language];

--- a/src/components/SupportSection.tsx
+++ b/src/components/SupportSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { ExternalLink, Table } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 
@@ -116,7 +116,7 @@ const translations = {
 } as const;
 
 export function SupportSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const {

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import * as React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const translations = {
@@ -69,7 +69,7 @@ const translations = {
 } as const;
 
 export function TestimonialsSection() {
-  const ref = useRef(null);
+  const ref = React.useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
   const { title, impactPoints, testimonials } = translations[language];


### PR DESCRIPTION
## Summary
- switch motion-driven sections to use the React namespace for `useRef`/`useState`/`useEffect` so the hooks are always resolved at runtime
- update all sections that relied on `useRef` to call the hooks via `React.*`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0dc0581fc83239bed9c0bc08fdcc9