### PR TITLE
Update senior mentors section with images and copy

### DIFF
--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -103,11 +103,11 @@ export function AuthoritySection() {
                   transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
                   className="flex flex-col items-center"
                 >
-                  <div className="w-40 h-40 sm:w-44 sm:h-44 rounded-full overflow-hidden shadow-lg bg-white">
+                  <div className="relative w-40 h-40 sm:w-44 sm:h-44 rounded-full overflow-hidden shadow-lg bg-white">
                     <img
                       src={mentor.image}
                       alt={language === 'ru' ? `Фото ${name}` : `Photo of ${name}`}
-                      className="h-full w-full object-cover object-center"
+                      className="absolute inset-0 h-full w-full object-cover"
                     />
                   </div>
                   <figcaption className="-mt-8 w-40 sm:w-44 bg-white px-4 py-3 rounded-full shadow-md text-center">

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -2,27 +2,68 @@ import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
 import { useRef } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import acyutatmaImage from '../assets/seniors_support/acyutatma.jpg';
+import kesavaImage from '../assets/seniors_support/kesava.png';
+import mukundaImage from '../assets/seniors_support/mukunda.png';
+import prabhupadaImage from '../assets/seniors_support/prabhupada.jpg';
+import vatsalaImage from '../assets/seniors_support/vatsala.png';
 
 const translations = {
   ru: {
     title: 'Взаимодействие со старшими',
     description:
-      'Мы действуем в духе уважения к старшим вайшнавам и стремимся к благословениям и наставлениям GBC и местной ятры. В новых регионах мы заранее делимся планами, обсуждаем формат служения и выстраиваем сотрудничество.',
-    leaders: ['Махараджа Прабху', 'Гуру Дев Прабху', 'Бхакти Прия Матаджи', 'Кришна Дас Прабху', 'Радха Прия Матаджи']
+      'Мы действуем в духе уважения к старшим вайшнавам и стремимся к благословениям GBC и местной ятры, следуя их наставлениям. В новых регионах мы заранее делимся планами, обсуждаем формат служения и выстраиваем сотрудничество.'
   },
   en: {
     title: 'Working with senior devotees',
     description:
-      'We serve with respect for senior Vaishnavas, seeking blessings and guidance from the GBC and the local yatra. In new regions we share plans in advance, discuss the service format, and build cooperation together.',
-    leaders: ['Maharaja Prabhu', 'Guru Dev Prabhu', 'Bhakti Priya Mataji', 'Krishna Das Prabhu', 'Radha Priya Mataji']
+      'We act with deep respect for senior Vaishnavas and seek the blessings of the GBC and the local yatra by following their guidance. In new regions we share plans in advance, discuss the service format, and build cooperation.'
   }
 } as const;
+
+const mentors = [
+  {
+    image: mukundaImage,
+    translations: {
+      ru: { name: 'Мукунда Мурари прабху', role: 'наставник проекта' },
+      en: { name: 'Mukunda Murari Prabhu', role: 'Project mentor' }
+    }
+  },
+  {
+    image: kesavaImage,
+    translations: {
+      ru: { name: 'Бхакти Бхагаватамрита Кешава Махарадж', role: 'наставник проекта в Батуми' },
+      en: { name: 'Bhakti Bhagavatamrita Keshava Maharaj', role: 'Project mentor in Batumi' }
+    }
+  },
+  {
+    image: acyutatmaImage,
+    translations: {
+      ru: { name: 'Ачьютатма прабху', role: 'доброжелатель проекта' },
+      en: { name: 'Acyutatma Prabhu', role: 'Project well-wisher' }
+    }
+  },
+  {
+    image: vatsalaImage,
+    translations: {
+      ru: { name: 'Ватсала прабху', role: 'доброжелатель проекта' },
+      en: { name: 'Vatsala Prabhu', role: 'Project well-wisher' }
+    }
+  },
+  {
+    image: prabhupadaImage,
+    translations: {
+      ru: { name: 'Шрила Прабхупада', role: 'Ачарья Основатель ИСККОН' },
+      en: { name: 'Śrīla Prabhupāda', role: 'Founder-Ācārya of ISKCON' }
+    }
+  }
+] as const;
 
 export function AuthoritySection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
   const { language } = useLanguage();
-  const { title, description, leaders } = translations[language];
+  const { title, description } = translations[language];
 
   return (
     <section id="reports" ref={ref} className="py-12 lg:py-20 bg-[#f8f6f3]">
@@ -49,19 +90,33 @@ export function AuthoritySection() {
             initial={{ opacity: 0, x: 50 }}
             animate={isInView ? { opacity: 1, x: 0 } : {}}
             transition={{ duration: 0.8, delay: 0.4 }}
-            className="flex flex-wrap gap-3 lg:justify-end"
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6 lg:gap-8 place-items-center"
           >
-            {leaders.map((leader, index) => (
-              <motion.div
-                key={leader}
-                initial={{ opacity: 0, y: 10 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.5, delay: 0.6 + index * 0.1 }}
-                className="bg-white px-4 py-2 rounded-full shadow-md text-[#73729b] font-medium"
-              >
-                {leader}
-              </motion.div>
-            ))}
+            {mentors.map((mentor, index) => {
+              const { name, role } = mentor.translations[language];
+
+              return (
+                <motion.figure
+                  key={name}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={isInView ? { opacity: 1, y: 0 } : {}}
+                  transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
+                  className="flex flex-col items-center"
+                >
+                  <div className="w-40 h-56 sm:w-44 sm:h-60 rounded-[120px] overflow-hidden shadow-lg">
+                    <img
+                      src={mentor.image}
+                      alt={language === 'ru' ? `Фото ${name}` : `Photo of ${name}`}
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                  <figcaption className="-mt-10 w-40 sm:w-44 bg-white px-4 py-3 rounded-full shadow-md text-center">
+                    <p className="font-menorah text-sm text-black leading-tight">{name}</p>
+                    <p className="text-xs text-[#73729b] mt-1 leading-snug">{role}</p>
+                  </figcaption>
+                </motion.figure>
+              );
+            })}
           </motion.div>
         </div>
       </div>

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -103,11 +103,11 @@ export function AuthoritySection() {
                   transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
                   className="flex flex-col items-center"
                 >
-                  <div className="relative w-40 h-40 sm:w-44 sm:h-44 rounded-full overflow-hidden shadow-lg bg-white">
+                  <div className="w-40 h-40 sm:w-44 sm:h-44 rounded-full overflow-hidden shadow-lg bg-white">
                     <img
                       src={mentor.image}
                       alt={language === 'ru' ? `Фото ${name}` : `Photo of ${name}`}
-                      className="absolute inset-0 h-full w-full object-cover"
+                      className="h-full w-full object-cover"
                     />
                   </div>
                   <figcaption className="-mt-8 w-40 sm:w-44 bg-white px-4 py-3 rounded-full shadow-md text-center">

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -103,14 +103,14 @@ export function AuthoritySection() {
                   transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
                   className="flex flex-col items-center"
                 >
-                  <div className="w-40 h-56 sm:w-44 sm:h-60 rounded-[120px] overflow-hidden shadow-lg">
+                  <div className="w-40 h-40 sm:w-44 sm:h-44 rounded-full overflow-hidden shadow-lg bg-white">
                     <img
                       src={mentor.image}
                       alt={language === 'ru' ? `Фото ${name}` : `Photo of ${name}`}
-                      className="h-full w-full object-cover"
+                      className="h-full w-full object-cover object-center"
                     />
                   </div>
-                  <figcaption className="-mt-10 w-40 sm:w-44 bg-white px-4 py-3 rounded-full shadow-md text-center">
+                  <figcaption className="-mt-8 w-40 sm:w-44 bg-white px-4 py-3 rounded-full shadow-md text-center">
                     <p className="font-menorah text-sm text-black leading-tight">{name}</p>
                     <p className="text-xs text-[#73729b] mt-1 leading-snug">{role}</p>
                   </figcaption>


### PR DESCRIPTION
## Summary
- update the senior interaction description in both languages to match the new messaging
- display senior mentors with localized names, roles, and official photos instead of placeholder badges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e381d2393883238e8b927991ea46e5