### PR TITLE
Add donation modals and refresh external links

### DIFF
--- a/src/components/ContactsSection.tsx
+++ b/src/components/ContactsSection.tsx
@@ -11,20 +11,26 @@ const translations = {
       {
         category: 'Артём',
         items: [
-          { icon: <MessageCircle size={24} />, label: 'Telegram', link: '#' },
-          { icon: <Phone size={24} />, label: 'WhatsApp', link: '#' }
+          { icon: <MessageCircle size={24} />, label: 'Telegram', link: 'https://t.me/omhome_cnx' },
+          { icon: <Phone size={24} />, label: 'WhatsApp', link: 'https://wa.me/79955970108' }
         ]
       },
       {
         category: 'Социальные сети',
         items: [
-          { icon: <MessageCircle size={24} />, label: 'Канал Telegram', link: '#' },
-          { icon: <Instagram size={24} />, label: 'Instagram', link: '#' }
+          { icon: <MessageCircle size={24} />, label: 'Telegram канал', link: 'https://t.me/omhome_thai' },
+          { icon: <Instagram size={24} />, label: 'Instagram', link: 'https://www.instagram.com/omhome.cnx' }
         ]
       },
       {
         category: 'Адрес:',
-        items: [{ icon: <MapPin size={24} />, label: 'Google Maps', link: '#' }]
+        items: [
+          {
+            icon: <MapPin size={24} />,
+            label: 'Google Maps',
+            link: 'https://maps.app.goo.gl/XRhHXGwcpKY2mDjW9'
+          }
+        ]
       }
     ],
     description:
@@ -36,20 +42,26 @@ const translations = {
       {
         category: 'Artyom',
         items: [
-          { icon: <MessageCircle size={24} />, label: 'Telegram', link: '#' },
-          { icon: <Phone size={24} />, label: 'WhatsApp', link: '#' }
+          { icon: <MessageCircle size={24} />, label: 'Telegram', link: 'https://t.me/omhome_cnx' },
+          { icon: <Phone size={24} />, label: 'WhatsApp', link: 'https://wa.me/79955970108' }
         ]
       },
       {
         category: 'Social media',
         items: [
-          { icon: <MessageCircle size={24} />, label: 'Telegram channel', link: '#' },
-          { icon: <Instagram size={24} />, label: 'Instagram', link: '#' }
+          { icon: <MessageCircle size={24} />, label: 'Telegram channel', link: 'https://t.me/omhome_thai' },
+          { icon: <Instagram size={24} />, label: 'Instagram', link: 'https://www.instagram.com/omhome.cnx' }
         ]
       },
       {
         category: 'Address:',
-        items: [{ icon: <MapPin size={24} />, label: 'Google Maps', link: '#' }]
+        items: [
+          {
+            icon: <MapPin size={24} />,
+            label: 'Google Maps',
+            link: 'https://maps.app.goo.gl/XRhHXGwcpKY2mDjW9'
+          }
+        ]
       }
     ],
     description:
@@ -95,6 +107,8 @@ export function ContactsSection() {
                     animate={isInView ? { opacity: 1, x: 0 } : {}}
                     transition={{ duration: 0.5, delay: 0.4 + groupIndex * 0.2 + itemIndex * 0.1 }}
                     whileHover={{ x: 5, scale: 1.02 }}
+                    target="_blank"
+                    rel="noreferrer"
                     className="flex items-center gap-3 text-xl text-black hover:text-[#73729b] transition-colors p-3 rounded-lg hover:bg-[#f8f6f3] group"
                   >
                     <div className="text-[#73729b] group-hover:scale-110 transition-transform">{item.icon}</div>

--- a/src/components/JoinSection.tsx
+++ b/src/components/JoinSection.tsx
@@ -269,7 +269,12 @@ export function JoinSection() {
           transition={{ duration: 0.6, delay: 0.8 }}
           className="text-center mb-16"
         >
-          <a href="#" className="text-xl text-[#241f74] underline hover:text-[#73729b] transition-colors">
+          <a
+            href="https://omhome-text.vercel.app/omhome"
+            target="_blank"
+            rel="noreferrer"
+            className="text-xl text-[#241f74] underline hover:text-[#73729b] transition-colors"
+          >
             {principlesLink}
           </a>
         </motion.div>

--- a/src/components/ProgramsSection.tsx
+++ b/src/components/ProgramsSection.tsx
@@ -212,13 +212,17 @@ export function ProgramsSection() {
               className="flex flex-wrap gap-4"
             >
               <a
-                href="#"
+                href="https://www.instagram.com/omhome.belgrade/"
+                target="_blank"
+                rel="noreferrer"
                 className="text-[#241f74] underline hover:text-[#73729b] transition-colors"
               >
                 Instagram / Belgrade
               </a>
               <a
-                href="#"
+                href="https://t.me/omhomespace"
+                target="_blank"
+                rel="noreferrer"
                 className="text-[#241f74] underline hover:text-[#73729b] transition-colors"
               >
                 Telegram / Batumi

--- a/src/components/SupportSection.tsx
+++ b/src/components/SupportSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { ExternalLink, Table } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 
@@ -12,9 +12,34 @@ const translations = {
       'арендовать дом, проводить программы, готовить прасад, украшать алтарь, поддерживать чистоту и оборудование.',
     paymentMethodsTitle: 'Способы превода',
     paymentMethods: [
-      { title: 'Криптовалюта', description: 'USDT/USDC/BTC и др.' },
-      { title: 'СБП', description: 'быстрые переводы внутри РФ' },
-      { title: 'SWIFT', description: 'международный банковский перевод' }
+      {
+        title: 'Криптовалюта',
+        description: 'USDT/USDC/BTC и др.',
+        details: [
+          'ByBit UID: 115189352',
+          'USDT TRC20: TUTZBW9sH341B7Rz43UnTU9sjVdbTCN1F5'
+        ],
+        note: 'После перевода сообщите: t.me/artarteemev'
+      },
+      {
+        title: 'СБП',
+        description: 'быстрые переводы внутри РФ',
+        details: [
+          'Телефон: +7 995 597 0108',
+          'Банки: Яндекс Банк / Сбербанк'
+        ],
+        note: 'После перевода сообщите: t.me/artarteemev'
+      },
+      {
+        title: 'SWIFT',
+        description: 'международный банковский перевод',
+        details: [
+          'IBAN: GE73TB7418145068100009USD',
+          'SWIFT: TBCBGE22',
+          'Получатель: Liubov Verba'
+        ],
+        note: 'После перевода сообщите: t.me/artarteemev'
+      }
     ],
     supportLevelsTitle: 'Уровни ежемесячной поддержки',
     supportLevels: [
@@ -27,6 +52,9 @@ const translations = {
     transparencyIntro: 'Ежемесячный отчёт',
     transparencyDetails: 'поступления/расходы по статьям (аренда, прасад, алтарь, быт, оборудование)',
     transparencyButton: 'Публичная сводная таблица',
+    transparencyLink: 'https://docs.google.com/spreadsheets/d/1gKSs7HlLdmP8QztPw4dCWq3Z_ci_Eh_1m7GP18JMTjM',
+    paymentModalTitle: 'Реквизиты',
+    paymentModalClose: 'Закрыть',
     targetedTitle: 'Целевые пожертвования',
     donationCategories: [
       {
@@ -66,9 +94,34 @@ const translations = {
       'rent the house, host programs, cook prasadam, decorate the altar, and keep everything clean and equipped.',
     paymentMethodsTitle: 'Payment methods',
     paymentMethods: [
-      { title: 'Cryptocurrency', description: 'USDT/USDC/BTC and more' },
-      { title: 'FPS', description: 'instant transfers within Russia' },
-      { title: 'SWIFT', description: 'international bank transfer' }
+      {
+        title: 'Cryptocurrency',
+        description: 'USDT/USDC/BTC and more',
+        details: [
+          'ByBit UID: 115189352',
+          'USDT TRC20: TUTZBW9sH341B7Rz43UnTU9sjVdbTCN1F5'
+        ],
+        note: 'After the transfer, message: t.me/artarteemev'
+      },
+      {
+        title: 'FPS',
+        description: 'instant transfers within Russia',
+        details: [
+          'Phone: +7 995 597 0108',
+          'Banks: Yandex Bank / Sberbank'
+        ],
+        note: 'After the transfer, message: t.me/artarteemev'
+      },
+      {
+        title: 'SWIFT',
+        description: 'international bank transfer',
+        details: [
+          'IBAN: GE73TB7418145068100009USD',
+          'SWIFT: TBCBGE22',
+          'Beneficiary: Liubov Verba'
+        ],
+        note: 'After the transfer, message: t.me/artarteemev'
+      }
     ],
     supportLevelsTitle: 'Monthly support tiers',
     supportLevels: [
@@ -81,6 +134,9 @@ const translations = {
     transparencyIntro: 'Monthly report',
     transparencyDetails: 'income and expenses by category (rent, prasadam, altar, household, equipment)',
     transparencyButton: 'Public summary spreadsheet',
+    transparencyLink: 'https://docs.google.com/spreadsheets/d/1gKSs7HlLdmP8QztPw4dCWq3Z_ci_Eh_1m7GP18JMTjM',
+    paymentModalTitle: 'Details',
+    paymentModalClose: 'Close',
     targetedTitle: 'Targeted donations',
     donationCategories: [
       {
@@ -115,6 +171,8 @@ const translations = {
   }
 } as const;
 
+type PaymentMethod = (typeof translations)['ru']['paymentMethods'][number];
+
 export function SupportSection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.2 });
@@ -131,117 +189,189 @@ export function SupportSection() {
     transparencyIntro,
     transparencyDetails,
     transparencyButton,
+    transparencyLink,
+    paymentModalTitle,
+    paymentModalClose,
     targetedTitle,
     donationCategories
   } = translations[language];
+  const [selectedMethod, setSelectedMethod] = useState<PaymentMethod | null>(null);
+
+  const handleSelectMethod = (method: PaymentMethod) => {
+    setSelectedMethod(method);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedMethod(null);
+  };
+
+  const modalTitleId = 'support-payment-modal-title';
 
   return (
-    <section id="support" ref={ref} className="py-16 lg:py-24 bg-[#f8f6f3]">
-      <div className="container mx-auto px-4">
-        <motion.h2
-          initial={{ opacity: 0, y: 50 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.8 }}
-          className="font-menorah text-4xl md:text-6xl lg:text-7xl text-black mb-16 text-center lg:text-left"
-        >
-          {title}
-        </motion.h2>
-
-        <div className="grid lg:grid-cols-2 gap-16 mb-16">
-          <motion.div
-            initial={{ opacity: 0, x: -50 }}
-            animate={isInView ? { opacity: 1, x: 0 } : {}}
-            transition={{ duration: 0.8, delay: 0.2 }}
+    <>
+      <section id="support" ref={ref} className="py-16 lg:py-24 bg-[#f8f6f3]">
+        <div className="container mx-auto px-4">
+          <motion.h2
+            initial={{ opacity: 0, y: 50 }}
+            animate={isInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.8 }}
+            className="font-menorah text-4xl md:text-6xl lg:text-7xl text-black mb-16 text-center lg:text-left"
           >
-            <h3 className="text-2xl font-bold text-[#73729b] mb-6">{donationsHelpTitle}</h3>
-            <p className="text-xl text-black leading-relaxed mb-8">{donationsHelpText}</p>
+            {title}
+          </motion.h2>
 
-            <h3 className="text-2xl font-bold text-[#73729b] mb-6">{paymentMethodsTitle}</h3>
-            <div className="space-y-4">
-              {paymentMethods.map((method, index) => (
-                <motion.div
-                  key={method.title}
-                  initial={{ opacity: 0, x: 20 }}
-                  animate={isInView ? { opacity: 1, x: 0 } : {}}
-                  transition={{ duration: 0.5, delay: 0.4 + index * 0.1 }}
-                  className="hover:bg-white p-4 rounded-lg transition-colors cursor-pointer"
-                >
-                  <h4 className="text-xl font-bold text-[#241f74] underline mb-1">{method.title}</h4>
-                  <p className="text-lg text-black">{method.description}</p>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
+          <div className="grid lg:grid-cols-2 gap-16 mb-16">
+            <motion.div
+              initial={{ opacity: 0, x: -50 }}
+              animate={isInView ? { opacity: 1, x: 0 } : {}}
+              transition={{ duration: 0.8, delay: 0.2 }}
+            >
+              <h3 className="text-2xl font-bold text-[#73729b] mb-6">{donationsHelpTitle}</h3>
+              <p className="text-xl text-black leading-relaxed mb-8">{donationsHelpText}</p>
 
-          <motion.div
-            initial={{ opacity: 0, x: 50 }}
-            animate={isInView ? { opacity: 1, x: 0 } : {}}
-            transition={{ duration: 0.8, delay: 0.4 }}
-          >
-            <h3 className="text-2xl font-bold text-[#73729b] mb-6">{supportLevelsTitle}</h3>
-            <div className="grid grid-cols-2 gap-4 mb-8">
-              {supportLevels.map((level, index) => (
-                <motion.div
-                  key={level.title}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={isInView ? { opacity: 1, scale: 1 } : {}}
-                  transition={{ duration: 0.5, delay: 0.6 + index * 0.1 }}
-                  whileHover={{ scale: 1.05 }}
-                  className="bg-white p-4 rounded-lg shadow-md cursor-pointer"
-                >
-                  <h4 className="text-lg font-bold text-[#241f74] underline mb-2">{level.title}</h4>
-                  <p className="text-sm text-black">{level.amount}</p>
-                </motion.div>
-              ))}
-            </div>
+              <h3 className="text-2xl font-bold text-[#73729b] mb-6">{paymentMethodsTitle}</h3>
+              <div className="space-y-4">
+                {paymentMethods.map((method, index) => (
+                  <motion.button
+                    type="button"
+                    key={method.title}
+                    initial={{ opacity: 0, x: 20 }}
+                    animate={isInView ? { opacity: 1, x: 0 } : {}}
+                    transition={{ duration: 0.5, delay: 0.4 + index * 0.1 }}
+                    onClick={() => handleSelectMethod(method)}
+                    className="w-full text-left hover:bg-white p-4 rounded-lg transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[#73729b]/60"
+                  >
+                    <h4 className="text-xl font-bold text-[#241f74] underline mb-1">{method.title}</h4>
+                    <p className="text-lg text-black">{method.description}</p>
+                  </motion.button>
+                ))}
+              </div>
+            </motion.div>
 
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.6, delay: 1 }}
-              className="bg-white p-6 rounded-xl shadow-lg"
+              initial={{ opacity: 0, x: 50 }}
+              animate={isInView ? { opacity: 1, x: 0 } : {}}
+              transition={{ duration: 0.8, delay: 0.4 }}
             >
-              <h4 className="text-xl font-bold text-[#73729b] mb-4">{transparencyTitle}</h4>
-              <p className="text-lg text-black leading-relaxed mb-4">
-                <span className="font-bold">{transparencyIntro}:</span> {transparencyDetails}
-              </p>
-              <button className="flex items-center gap-2 text-[#4b4a73] underline hover:text-[#73729b] transition-colors">
-                <Table size={20} />
-                {transparencyButton}
-                <ExternalLink size={16} />
+              <h3 className="text-2xl font-bold text-[#73729b] mb-6">{supportLevelsTitle}</h3>
+              <div className="grid grid-cols-2 gap-4 mb-8">
+                {supportLevels.map((level, index) => (
+                  <motion.a
+                    key={level.title}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={isInView ? { opacity: 1, scale: 1 } : {}}
+                    transition={{ duration: 0.5, delay: 0.6 + index * 0.1 }}
+                    whileHover={{ scale: 1.05 }}
+                    href="http://boosty.to/omhomespace"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="bg-white p-4 rounded-lg shadow-md cursor-pointer block"
+                  >
+                    <h4 className="text-lg font-bold text-[#241f74] underline mb-2">{level.title}</h4>
+                    <p className="text-sm text-black">{level.amount}</p>
+                  </motion.a>
+                ))}
+              </div>
+
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={isInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.6, delay: 1 }}
+                className="bg-white p-6 rounded-xl shadow-lg"
+              >
+                <h4 className="text-xl font-bold text-[#73729b] mb-4">{transparencyTitle}</h4>
+                <p className="text-lg text-black leading-relaxed mb-4">
+                  <span className="font-bold">{transparencyIntro}:</span> {transparencyDetails}
+                </p>
+                <a
+                  href={transparencyLink}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 text-[#4b4a73] underline hover:text-[#73729b] transition-colors"
+                >
+                  <Table size={20} />
+                  {transparencyButton}
+                  <ExternalLink size={16} />
+                </a>
+              </motion.div>
+            </motion.div>
+          </div>
+
+          {/* Donation Categories */}
+          <motion.h3
+            initial={{ opacity: 0, y: 30 }}
+            animate={isInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.8 }}
+            className="text-2xl font-bold text-[#73729b] mb-8 text-center"
+          >
+            {targetedTitle}
+          </motion.h3>
+
+          <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-6 mb-12">
+            {donationCategories.map((category, index) => (
+              <motion.div
+                key={category.title}
+                initial={{ opacity: 0, y: 50 }}
+                animate={isInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.6, delay: 1 + index * 0.1 }}
+                whileHover={{ y: -5, scale: 1.02 }}
+                className={`${category.color} text-white p-6 rounded-xl shadow-lg cursor-pointer`}
+              >
+                <div className="text-5xl mb-4 text-center">{category.emoji}</div>
+                <h4 className="text-xl font-bold text-center mb-4">{category.title}</h4>
+                <p className="text-base leading-relaxed mb-4">{category.description}</p>
+                <p className="text-base font-semibold leading-relaxed">{category.quote}</p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {selectedMethod ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+          <button
+            type="button"
+            onClick={handleCloseModal}
+            className="absolute inset-0 w-full h-full cursor-pointer"
+            aria-label={paymentModalClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+            onClick={(event) => event.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={modalTitleId}
+            className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl"
+          >
+            <h4 id={modalTitleId} className="text-2xl font-bold text-[#241f74] mb-4">
+              {paymentModalTitle} — {selectedMethod.title}
+            </h4>
+            <ul className="space-y-2 mb-4">
+              {selectedMethod.details.map((detail) => (
+                <li key={detail} className="text-lg text-black leading-relaxed">
+                  {detail}
+                </li>
+              ))}
+            </ul>
+            {selectedMethod.note ? (
+              <p className="text-base text-[#4b4a73] leading-relaxed mb-6">{selectedMethod.note}</p>
+            ) : null}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleCloseModal}
+                className="px-4 py-2 text-base font-semibold text-white bg-[#73729b] rounded-lg hover:bg-[#4b4a73] transition-colors"
+              >
+                {paymentModalClose}
               </button>
-            </motion.div>
+            </div>
           </motion.div>
         </div>
-
-        {/* Donation Categories */}
-        <motion.h3
-          initial={{ opacity: 0, y: 30 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.8 }}
-          className="text-2xl font-bold text-[#73729b] mb-8 text-center"
-        >
-          {targetedTitle}
-        </motion.h3>
-
-        <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-6 mb-12">
-          {donationCategories.map((category, index) => (
-            <motion.div
-              key={category.title}
-              initial={{ opacity: 0, y: 50 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.6, delay: 1 + index * 0.1 }}
-              whileHover={{ y: -5, scale: 1.02 }}
-              className={`${category.color} text-white p-6 rounded-xl shadow-lg cursor-pointer`}
-            >
-              <div className="text-5xl mb-4 text-center">{category.emoji}</div>
-              <h4 className="text-xl font-bold text-center mb-4">{category.title}</h4>
-              <p className="text-base leading-relaxed mb-4">{category.description}</p>
-              <p className="text-base font-semibold leading-relaxed">{category.quote}</p>
-            </motion.div>
-          ))}
-        </div>
-      </div>
-    </section>
+      ) : null}
+    </>
   );
+
 }

--- a/src/pages/ChiangMaiHomePage.tsx
+++ b/src/pages/ChiangMaiHomePage.tsx
@@ -86,7 +86,7 @@ export function ChiangMaiHomePage() {
             </a>
             <a
               className={styles.heroButton}
-              href="https://instagram.com/omhome_cnx"
+              href="https://www.instagram.com/omhome.cnx"
               target="_blank"
               rel="noreferrer"
             >
@@ -251,7 +251,7 @@ export function ChiangMaiHomePage() {
           </div>
           <a
             className={styles.happeningsButton}
-            href="https://instagram.com/omhome_cnx"
+            href="https://www.instagram.com/omhome.cnx"
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
## Summary
- add detailed donation method translations and pop-up modal for support payment options
- link monthly support tiers, transparency spreadsheet, and contact/social blocks to their public destinations
- update Chiang Mai hero and happenings buttons along with program references to the latest Instagram and Telegram URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4d931520c83239d14241297bbc4f9