### PR TITLE
Improve Pamho senior mentors layout and update about copy

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -10,17 +10,17 @@ const translations = {
       who: {
         title: 'Кто мы:',
         description:
-          'OmHome — социальный проповеднический вайшнавский проект. Наша цель — поддерживать и развивать проповедь в местах, где нет активных общин, но есть энтузиазм семей преданных.'
+          'У нас настоящий дом преданных: здесь постоянно живут вайшнавы, и вы тоже можете приехать пожить, послужить и вдохновиться вместе с нами.'
       },
       what: {
         title: 'Что делаем:',
         description:
-          'соединяем духовные программы (киртаны, лекции, санги, нама‑хатты) с социальными событиями (кинопоказы, настольные игры, йога, мастер‑классы), чтобы мягко знакомить людей с вайшнавской культурой.'
+          'проводим регулярные проповеднические программы: киртаны, лекции, санги, нама‑хатты, беседы по шастрам, встречи для гостей, семейные вечера, творческие мастер‑классы и служение в городе.'
       },
       how: {
         title: 'Как устроено:',
         description:
-          'это не просто центр — это дом, где живут преданные и где естественно рождаются отношения, забота и служение.'
+          'дом открыт для приезжающих преданных и интересующихся: мы встречаем лично, помогаем встроиться в ритм, вовлекаем в служение и поддерживаем заботой.'
       }
     },
     stats: [
@@ -35,17 +35,17 @@ const translations = {
       who: {
         title: 'Who we are:',
         description:
-          'OmHome is a social Vaishnava outreach project. Our goal is to support and develop preaching where there are no active communities yet, but devotee families are eager to serve.'
+          'We have a real devotee home: Vaishnavas live here full-time, and you are welcome to visit, stay with us, serve, and find inspiration.'
       },
       what: {
         title: 'What we do:',
         description:
-          'We combine spiritual programs (kirtans, lectures, sangas, nama-hattas) with social events (movie nights, board games, yoga, workshops) to gently introduce people to Vaishnava culture.'
+          'We host regular preaching programs: kirtans, lectures, sangas, nama-hattas, scripture discussions, gatherings for guests, family evenings, creative workshops, and city outreach service.'
       },
       how: {
         title: 'How it works:',
         description:
-          "It's not just a center—it's a home where devotees live, and relationships, care, and service grow naturally."
+          "The home is open to visiting devotees and seekers: we greet everyone personally, help them settle into the rhythm, engage them in service, and surround them with care."
       }
     },
     stats: [

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -10,7 +10,7 @@ const translations = {
       who: {
         title: 'Кто мы:',
         description:
-          'У нас настоящий дом преданных: здесь постоянно живут вайшнавы, и вы тоже можете приехать пожить, послужить и вдохновиться вместе с нами.'
+          'Мы находимся в Чианг Мае, Таиланд — у нас настоящий дом преданных: здесь постоянно живут вайшнавы, и вы тоже можете приехать пожить, послужить и вдохновиться вместе с нами.'
       },
       what: {
         title: 'Что делаем:',
@@ -35,7 +35,7 @@ const translations = {
       who: {
         title: 'Who we are:',
         description:
-          'We have a real devotee home: Vaishnavas live here full-time, and you are welcome to visit, stay with us, serve, and find inspiration.'
+          'We are based in Chiang Mai, Thailand — we have a real devotee home: Vaishnavas live here full-time, and you are welcome to visit, stay with us, serve, and find inspiration.'
       },
       what: {
         title: 'What we do:',

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -90,7 +90,7 @@ export function AuthoritySection() {
             initial={{ opacity: 0, x: 50 }}
             animate={isInView ? { opacity: 1, x: 0 } : {}}
             transition={{ duration: 0.8, delay: 0.4 }}
-            className="flex flex-wrap justify-center gap-10"
+            className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5 gap-8 justify-items-center"
           >
             {mentors.map((mentor, index) => {
               const { name, role } = mentor.translations[language];
@@ -101,16 +101,16 @@ export function AuthoritySection() {
                   initial={{ opacity: 0, y: 20 }}
                   animate={isInView ? { opacity: 1, y: 0 } : {}}
                   transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
-                  className="flex flex-col items-center w-[300px] pb-6"
+                  className="flex flex-col items-center w-full max-w-[220px] pb-6"
                 >
-                  <div className="w-full overflow-hidden rounded-3xl shadow-lg bg-white">
+                  <div className="relative w-full aspect-[57/40] overflow-hidden rounded-3xl shadow-lg bg-white bg-cover">
                     <img
                       src={mentor.image}
                       alt={language === 'ru' ? `Фото ${name}` : `Photo of ${name}`}
-                      className="w-full h-auto object-cover"
+                      className="absolute inset-0 h-full w-full object-cover"
                     />
                   </div>
-                  <figcaption className="mt-4 w-full bg-white px-6 py-4 rounded-3xl shadow-md text-center">
+                  <figcaption className="mt-4 w-full bg-white px-4 py-4 rounded-3xl shadow-md text-center">
                     <p className="font-menorah text-base text-black leading-tight">{name}</p>
                     <p className="text-sm text-[#73729b] mt-2 leading-snug">{role}</p>
                   </figcaption>

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -2,6 +2,7 @@ import { motion } from 'motion/react';
 import { useInView } from 'motion/react';
 import { useRef } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { AspectRatio } from './ui/aspect-ratio';
 import acyutatmaImage from '../assets/seniors_support/acyutatma.jpg';
 import kesavaImage from '../assets/seniors_support/kesava.png';
 import mukundaImage from '../assets/seniors_support/mukunda.png';
@@ -103,13 +104,16 @@ export function AuthoritySection() {
                   transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
                   className="flex flex-col items-center w-full max-w-[220px] pb-6"
                 >
-                  <div className="relative w-full aspect-[57/40] overflow-hidden rounded-3xl shadow-lg bg-white bg-cover">
+                  <AspectRatio
+                    ratio={57 / 40}
+                    className="w-full overflow-hidden rounded-3xl shadow-lg bg-white"
+                  >
                     <img
                       src={mentor.image}
                       alt={language === 'ru' ? `Фото ${name}` : `Photo of ${name}`}
-                      className="absolute inset-0 h-full w-full object-cover"
+                      className="h-full w-full object-cover"
                     />
-                  </div>
+                  </AspectRatio>
                   <figcaption className="mt-4 w-full bg-white px-4 py-4 rounded-3xl shadow-md text-center">
                     <p className="font-menorah text-base text-black leading-tight">{name}</p>
                     <p className="text-sm text-[#73729b] mt-2 leading-snug">{role}</p>

--- a/src/components/AuthoritySection.tsx
+++ b/src/components/AuthoritySection.tsx
@@ -91,7 +91,7 @@ export function AuthoritySection() {
             initial={{ opacity: 0, x: 50 }}
             animate={isInView ? { opacity: 1, x: 0 } : {}}
             transition={{ duration: 0.8, delay: 0.4 }}
-            className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5 gap-8 justify-items-center"
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6 justify-items-center"
           >
             {mentors.map((mentor, index) => {
               const { name, role } = mentor.translations[language];
@@ -102,11 +102,11 @@ export function AuthoritySection() {
                   initial={{ opacity: 0, y: 20 }}
                   animate={isInView ? { opacity: 1, y: 0 } : {}}
                   transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
-                  className="flex flex-col items-center w-full max-w-[220px] pb-6"
+                  className="w-full max-w-[180px] bg-white rounded-3xl shadow-md overflow-hidden"
                 >
                   <AspectRatio
                     ratio={57 / 40}
-                    className="w-full overflow-hidden rounded-3xl shadow-lg bg-white"
+                    className="w-full"
                   >
                     <img
                       src={mentor.image}
@@ -114,9 +114,9 @@ export function AuthoritySection() {
                       className="h-full w-full object-cover"
                     />
                   </AspectRatio>
-                  <figcaption className="mt-4 w-full bg-white px-4 py-4 rounded-3xl shadow-md text-center">
-                    <p className="font-menorah text-base text-black leading-tight">{name}</p>
-                    <p className="text-sm text-[#73729b] mt-2 leading-snug">{role}</p>
+                  <figcaption className="px-4 py-5 text-center">
+                    <p className="font-menorah text-sm text-black leading-tight">{name}</p>
+                    <p className="text-xs text-[#73729b] mt-2 leading-snug">{role}</p>
                   </figcaption>
                 </motion.figure>
               );


### PR DESCRIPTION
## Summary
- refresh the "Коротко о проекте" section text in both languages to highlight the devotee home and specific preaching formats
- rework the senior mentors block into a responsive grid with consistent card sizing for images and captions
- preserve the mentors’ photo aspect ratio with cover-based positioning to avoid stretched portraits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ecf208e8888323b12e6a6d8de838b3